### PR TITLE
Support a diffuse color of VRM

### DIFF
--- a/ui/properties_menu.py
+++ b/ui/properties_menu.py
@@ -54,7 +54,7 @@ class PropertiesMenu(bpy.types.Operator):
                         col.prop(item.mat.node_tree.nodes['mmd_shader'].inputs['Diffuse Color'], 'default_value',
                                  text='')
                     elif shader == 'vrm':
-                        col.prop(item.mat.node_tree.nodes['Group'].inputs[10], 'default_value', text='')
+                        col.prop(item.mat.node_tree.nodes["RGB"].outputs[0], 'default_value', text='')
                 else:
                     col.prop(item.mat, 'diffuse_color', text='')
                 col.separator()

--- a/utils/materials.py
+++ b/utils/materials.py
@@ -78,6 +78,8 @@ def get_diffuse(mat):
         shader = shader_type(mat) if mat else False
         if shader == 'mmdCol':
             return rgb_to_255_scale(mat.node_tree.nodes['mmd_shader'].inputs['Diffuse Color'].default_value[:])
+        elif shader == 'vrm':
+            return rgb_to_255_scale(mat.node_tree.nodes["RGB"].outputs[0].default_value[:])
         elif shader == 'vrmCol':
             return rgb_to_255_scale(mat.node_tree.nodes['Group'].inputs[10].default_value[:])
         elif shader == 'diffuseCol':


### PR DESCRIPTION
Note: In now, this PR is just like a notify for original authors about this experimental feature that is diffuse color supporting for VRM data. I have not tested much yet.

### Motivation

- I was make a VRM data used VRoid Studio and I needed detune it for a low resource runtime environment. Then, I found the great add-on and tried it.
- But, my VRM data is using both of a texture and a diffuse color in a material thus the trial used the original 2.1.1.5 was failed. It was only effected to a texture part.
- I know an easy workaround because I can edit directly an atlas-ed texture.
- However, I like a programable automation and it seems to easy, thus I read the source codes and tried an experimental supporting about diffuse color of VRM data.

-----
I'll notify again if I can test it enough.