### PR TITLE
Change defaults for gaps between images

### DIFF
--- a/extend_types.py
+++ b/extend_types.py
@@ -106,7 +106,7 @@ def register():
         max=32,
         precision=0,
         step=200,
-        default=2,
+        default=0,
         options={'HIDDEN'})
     bpy.types.Scene.smc_save_path = StringProperty(
         description='Select the directory in which the generated texture atlas will be saved',

--- a/operators/combiner/combiner.py
+++ b/operators/combiner/combiner.py
@@ -39,7 +39,7 @@ class Combiner(bpy.types.Operator):
         bpy.ops.smc.refresh_ob_data()
         if self.cats:
             scn.smc_size = 'PO2'
-            scn.smc_gaps = 16.0
+            scn.smc_gaps = 0.0
         set_ob_mode(context.view_layer if globs.version > 0 else scn)
         self.data = get_data(scn.smc_ob_data)
         self.mats_uv = get_mats_uv(self.data)


### PR DESCRIPTION
Hi! I'm requesting this change for a few reasons:
* Default settings should make things easier for people who don't know a lot about what they're doing
* In Power of Two mode, if textures are already in power of two sizes, it causes the resulting texture to be double the size it could've been if a user doesn't already know to change gaps to zero. If textures are already POT sized, this is bad.
* Pushing people to using non-power of two sizes just means the result will be scaled up/down when imported, which is confusing for people who don't already understand the texture import process.
* When dealing with textures >512x512, it will likely lead to an output size larger than the default Unity texture limit of 2048, so the result will be shrunk down in Unity. 
* It encourages people to tell Unity to store the texture as 4096x4096, which takes up a lot of VRAM for empty unused space.
* In the best situation, UVs should be contained within the bounds of the source texture before atlasing. When they're not, though, material combiner already takes care of the wrapping seperately, so spacing them out doesn't really help.
* When combining textures, the colour of the border isn't set by the surrounding textures, so when mipmapped it creates white seams.