### PR TITLE
Add support for Blender 2.93 and some small fixes

### DIFF
--- a/addon_updater_ops.py
+++ b/addon_updater_ops.py
@@ -62,7 +62,10 @@ Updater.addon = "smc"
 def make_annotations(cls):
     if not hasattr(bpy.app, "version") or bpy.app.version < (2, 80):
         return cls
-    bl_props = {k: v for k, v in cls.__dict__.items() if isinstance(v, tuple)}
+    if bpy.app.version < (2, 93, 0):
+        bl_props = {k: v for k, v in cls.__dict__.items() if isinstance(v, tuple)}
+    else:
+        bl_props = {k: v for k, v in cls.__dict__.items() if isinstance(v, bpy.props._PropertyDeferred)}
     if bl_props:
         if '__annotations__' not in cls.__dict__:
             setattr(cls, '__annotations__', {})

--- a/operators/combiner/combiner.py
+++ b/operators/combiner/combiner.py
@@ -18,6 +18,8 @@ class Combiner(bpy.types.Operator):
     structure = None
 
     def execute(self, context):
+        if not self.data:
+            self.invoke(context, None)
         scn = context.scene
         scn.smc_save_path = self.directory
         self.structure = BinPacker(get_size(scn, self.structure)).fit()
@@ -57,5 +59,6 @@ class Combiner(bpy.types.Operator):
             bpy.ops.smc.refresh_ob_data()
             self.report({'ERROR'}, 'No unique materials selected')
             return {'FINISHED'}
-        context.window_manager.fileselect_add(self)
+        if event is not None:
+            context.window_manager.fileselect_add(self)
         return {'RUNNING_MODAL'}

--- a/operators/combiner/combiner_ops.py
+++ b/operators/combiner/combiner_ops.py
@@ -24,6 +24,9 @@ from ...utils.textures import get_texture
 from ...utils.images import get_image
 from ...utils.images import get_image_path
 
+if Image:
+    Image.MAX_IMAGE_PIXELS = None
+
 
 def set_ob_mode(scn):
     obs = get_obs(scn.objects)

--- a/registration.py
+++ b/registration.py
@@ -80,7 +80,10 @@ def unregister_classes():
 
 def make_annotations(cls):
     if globs.version:
-        bl_props = {k: v for k, v in cls.__dict__.items() if isinstance(v, tuple)}
+        if bpy.app.version < (2, 93, 0):
+            bl_props = {k: v for k, v in cls.__dict__.items() if isinstance(v, tuple)}
+        else:
+            bl_props = {k: v for k, v in cls.__dict__.items() if isinstance(v, bpy.props._PropertyDeferred)}
         if bl_props:
             if '__annotations__' not in cls.__dict__:
                 setattr(cls, '__annotations__', {})


### PR DESCRIPTION
I added support for Blender 2.93, fixed an error when an image is too large and made the Combiner callable with bpy.ops.smc.combiner("EXEC_DEFAULT")