### PR TITLE
Fix #40: UI error when material has no preview.

### DIFF
--- a/extend_lists.py
+++ b/extend_lists.py
@@ -15,7 +15,11 @@ class SMC_UL_Combine_List(bpy.types.UIList):
                          emboss=False).list_id = index
         elif item.type == 1:
             row.separator()
-            row.label(text='', icon_value=item.mat.preview.icon_id)
+            mat_preview = item.mat.preview
+            if mat_preview:
+                row.label(text='', icon_value=mat_preview.icon_id)
+            else:
+                row.label(text='', icon='QUESTION')
             row.prop(item.mat, 'name', text='')
             col = row.column(align=True)
             col.alignment = 'RIGHT'


### PR DESCRIPTION
Materials don't necessarily always have a preview, this causes an error in some of the UI code that attempts to get the icon_id of the material's preview and seems like it might be preventing atlas creation in some cases.

You can also reproduce #40 in the Material List UI by assigning a newly created material to one of the material slots without having any of blender's UI open that attempts to display the material preview (and thus causes the preview to be generated).
In Blender's Python console, run:
`bpy.context.object.material_slots[0].material = bpy.data.materials.new('new_mat')`
when you have a mesh selected with at least one material slot and then update and view the Material List and you will have a material without a preview in the list (I ran and tested this in Blender 3.0):
Before patch (spams the system console with the error):
![image](https://user-images.githubusercontent.com/495015/163593433-0c06098a-181a-4c08-af10-752d46ef839c.png)
After patch:
![image](https://user-images.githubusercontent.com/495015/163592588-0d5fc316-0a84-44ff-99f9-56f9ed928084.png)

This patch makes the UI more robust against materials without previews. You could also run the `preview_ensure()` method of each `bpy.types.Material` when they're being gathered into the material list, but I'm not familiar with the code.