### PR TITLE
Get unique atlas name by checking save directory

### DIFF
--- a/operators/combiner/combiner_ops.py
+++ b/operators/combiner/combiner_ops.py
@@ -1,7 +1,7 @@
 import math
 import numpy as np
 import os
-import random
+import re
 from collections import OrderedDict
 from collections import defaultdict
 from itertools import chain
@@ -308,12 +308,25 @@ def get_comb_mats(scn, atlas: Image, mats_uv: MatsUV):
         if combine_list_item.type == globs.C_L_MATERIAL:
             if combine_list_item.used and combine_list_item.mat in mats_uv[combine_list_item.ob.name]:
                 layers.add(combine_list_item.layer)
-            mat_name = combine_list_item.mat.name
-            if mat_name.startswith('material_atlas_'):
-                existed_id = int(mat_name.split('_')[-2])
-                existed_ids.add(existed_id)
-    available_ids = set(range(10000, 99999)) - existed_ids
-    unique_id = random.choice(list(available_ids))
+    # Make sure that when we save the atlas, that it doesn't overwrite an existing file by finding all existing atlases
+    # in the smc_save_path directory and extracting the unique id of each
+    if os.path.isdir(scn.smc_save_path):
+        # Pattern matching the 'Atlas_{0}.png'.format(unique_id) format used below when naming atlases
+        atlas_file_pattern = re.compile(r"Atlas_(\d+).png")
+        for file_or_directory_name in os.listdir(scn.smc_save_path):
+            # Match against the full string
+            match = atlas_file_pattern.fullmatch(file_or_directory_name)
+            if match:
+                # (\d+) is the only subgroup, so it will be at index 1 (index 0 is the fully matched string)
+                existed_ids.add(int(match.group(1)))
+    unique_id = 1
+    while unique_id in existed_ids:
+        # Add one until the id doesn't already exist
+        unique_id += 1
+    # Format for at least 5 digits, this keeps generated atlases in order when sorted alphabetically, up to 5 digits.
+    # e.g. Atlas_10.png would be sorted alphabetically before Atlas_9.png despite typically being generated afterwards,
+    # whereas Atlas_00010.png would be sorted after Atlas_00009.png
+    unique_id = "{0:05d}".format(unique_id)
     atlas_name = 'Atlas_{0}.png'.format(unique_id)
     path = os.path.join(scn.smc_save_path, atlas_name)
     atlas.name = atlas_name


### PR DESCRIPTION
- Get the existing atlas names and their unique ids by checking the names of the files already in the save directory. Using the found unique ids, create a unique name for the newly generated atlas.
- This fixes #52 and similar errors that occur when trying to atlas materials that start with "material_atlas_" but are either missing a second underscore, have extra underscores or have a "unique_id" which isn't numeric, by replacing the code in question.
- This also fixes a very small chance of generated atlases overwriting existing atlas image files in the save directory, since the randomly chosen `unique_id` could end up being the same as an already existing file in the save directory.

-----

Formatting the `unique_id` to always display at least 5 digits is probably a bit excessive, but I did it to match the previous unique ids that would always be 5 digits. If you want, reduce it by changing the 5 in `{0:05d}` to a smaller number.
With this change, the ids are no longer random and instead start from 1 and increment until a unique id is found. I couldn't see a reason that they needed to remain random.