### PR TITLE
Perform max size check after PO2/QUAD resizing

### DIFF
--- a/utils/images.py
+++ b/utils/images.py
@@ -10,6 +10,17 @@ def is_single_colour_generated(img):
     return img.source == 'GENERATED' and not img.is_dirty and img.generated_type == 'BLANK'
 
 
+def is_image_too_large(width, height, components_per_pixel=4) -> bool:
+    # The total length of an image's pixels array cannot exceed the signed integer maximum, which is usually
+    # 2147483647 (for 32-bit signed integers). For a square image, this maximum is first exceeded by a
+    # 23171x23171 pixel image.
+    # If this maximum is exceeded, the length of the array will overflow in Blender's code, leading to an error
+    # message like "TypeError: expected sequence size -2147483648, got -2147483648" when trying to set the
+    # image's pixels.
+    # Width * height * r,g,b,a
+    return (width * height * components_per_pixel) > np.iinfo(np.intc).max
+
+
 # Convert a single color generated image to a color
 # The image's generated color is in linear, if the image is in sRGB, the color must be converted
 def single_color_generated_to_color(img, diffuse_to_multiply=None, target_colorspace='sRGB'):


### PR DESCRIPTION
The max size check was occurring before resizing due to the `PO2` or `QUAD` Atlas Size modes, which could cause the maximum size to be exceeded after the check.

The max size is also now based on the maximum number of pixels rather than an arbitrary number. Outside of custom Blender builds, the maximum number of pixels is the maximum 32bit signed integer: 2147483647, which, given a square image, would first be exceeded by a 23171x23171px image.

I also added the atlas size to the 'Output image size is too large' message that is displayed to users.

---

As the `CUST` Atlas Size mode specifies maximum size, it only ever shrinks the atlas, so no checking is needed after it. Checking the `CUST` Atlas Size beforehand is also pointless since the atlas pixels have to be written before resizing can take place.

Without this change, you would get this slightly confusing Python error if the atlas exceeds the maximum size due to the `PO2` or `QUAD` Atlas Size modes:
```
Traceback (most recent call last):
  File "C:\Users\<user>\AppData\Roaming\Blender Foundation\Blender\3.3\scripts\addons\material-combiner-addon-dev-build\operators\combiner\combiner.py", line 41, in execute
    atlas, packed_atlas_size = get_atlas(scn, self.structure, size)
  File "C:\Users\<user>\AppData\Roaming\Blender Foundation\Blender\3.3\scripts\addons\material-combiner-addon-dev-build\operators\combiner\combiner_ops.py", line 272, in get_atlas
    atlas = buffer_to_image(atlas_pixel_buffer, name='temp_material_combine_atlas')
  File "C:\Users\<user>\AppData\Roaming\Blender Foundation\Blender\3.3\scripts\addons\material-combiner-addon-dev-build\utils\pixels\pixel_buffer.py", line 149, in buffer_to_image
    write_pixel_buffer(image, buffer)
  File "C:\Users\<user>\AppData\Roaming\Blender Foundation\Blender\3.3\scripts\addons\material-combiner-addon-dev-build\utils\pixels\pixel_buffer.py", line 139, in write_pixel_buffer
    pixel_access.set_pixels(image, buffer)
  File "C:\Users\<user>\AppData\Roaming\Blender Foundation\Blender\3.3\scripts\addons\material-combiner-addon-dev-build\utils\pixels\fast_pixel_access_2_83_plus.py", line 16, in set_pixels
    img.pixels.foreach_set(buffer.ravel())
TypeError: expected sequence size -2147483648, got -2147483648```