### PR TITLE
Limit material list to only visible objects

### DIFF
--- a/globs.py
+++ b/globs.py
@@ -3,6 +3,7 @@ import bpy
 is_blender_2_79_or_older = bpy.app.version < (2, 80, 0)
 is_blender_2_80_or_newer = not is_blender_2_79_or_older
 is_blender_2_81_or_newer = bpy.app.version >= (2, 81)
+is_blender_3_2_or_newer = bpy.app.version >= (3, 2)
 
 # Change to True to enable debug print statements
 debug = False

--- a/operators/combiner/combiner.py
+++ b/operators/combiner/combiner.py
@@ -58,7 +58,7 @@ class Combiner(bpy.types.Operator):
         if self.cats:
             scn.smc_size = 'PO2'
             scn.smc_gaps = 0.0
-        set_ob_mode(context.view_layer if globs.is_blender_2_80_or_newer else scn)
+        set_ob_mode(context)
         self.data = get_data(scn.smc_ob_data)
         self.mats_uv = get_mats_uv(scn, self.data)
         clear_empty_mats(scn, self.data, self.mats_uv)

--- a/operators/ui/combine_list.py
+++ b/operators/ui/combine_list.py
@@ -4,7 +4,6 @@ import bpy
 from bpy.props import *
 from ...utils.materials import get_materials
 from ...utils.materials import sort_materials
-from ...utils.objects import get_obs
 from ... import globs
 
 class RefreshObData(bpy.types.Operator):
@@ -29,8 +28,8 @@ class RefreshObData(bpy.types.Operator):
                 old_layers[old_combine_item.ob][old_combine_item.mat] = old_combine_item.layer
         # Clear the old data from the scene
         scn.smc_ob_data.clear()
-        # Iterate through all the non-hidden mesh objects in the scene
-        for idx, ob in enumerate(get_obs(scn.objects)):
+        # Iterate through all visible mesh objects in the current context
+        for idx, ob in enumerate(ob for ob in context.visible_objects if ob.type == 'MESH' and ob.data.uv_layers.active):
             mat_dict = sort_materials(get_materials(ob))
             item = scn.smc_ob_data.add()
             item.type = globs.C_L_OBJECT

--- a/utils/objects.py
+++ b/utils/objects.py
@@ -1,13 +1,6 @@
 import math
 from collections import defaultdict
 
-from .. import globs
-
-
-def get_obs(obs):
-    return [ob for ob in obs if ob.type == 'MESH' and
-            ob.data.uv_layers.active and not (ob.hide_get() if globs.is_blender_2_80_or_newer else ob.hide)]
-
 
 def get_polys(ob):
     polys = defaultdict(list)


### PR DESCRIPTION
Checking Object.hide_get isn't enough to determine if an Object is hidden as it could also be disabled globally in the viewport (can be checked with Object.hide_viewport) or all the Collections the Object is in could be hidden either temporarily or globally, which would also hide the Object.
Object.visible_get can be used to test if an Object is visible, taking into account all visibility settings, alternatively, given a screen Context, Context.visible_objects provides access to all Objects visible in that Context, which is what this PR uses.

---

- Only set Objects in the material list to OBJECT mode
Don't need to get the visible Objects again when they're already available in the material list. Currently the visible objects and material list should always be the same, but this change makes it more robust in-case the visible objects and objects in the material list can become different in the future
- Use context overrides to set Objects to OBJECT mode without changing the active Object
- Fixes #45