### PR TITLE
Pressing Save Atlas To re-selects all materials #76

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -24,7 +24,7 @@ bl_info = {
     'name': "Shotariya's Material Combiner",
     'description': 'Public Release Material Combiner 2',
     'author': 'shotariya',
-    'version': (2, 1, 2, 7),
+    'version': (2, 1, 2, 8),
     'blender': (2, 80, 0),
     'location': 'View3D',
     # 'warning': '',

--- a/addon_updater.py
+++ b/addon_updater.py
@@ -121,7 +121,7 @@ class SingletonUpdater(object):
         self._error_msg = None
         self._prefiltered_tag_count = 0
 
-        # UI code only, ie not used within this module but still useful
+        # UI code only, i.e., not used within this module but still useful
         # properties to have
 
         # to verify a valid import, in place of placeholder import

--- a/extend_types.py
+++ b/extend_types.py
@@ -7,18 +7,22 @@ from . import addon_updater_ops
 class CombineList(bpy.types.PropertyGroup):
     ob = PointerProperty(
         name='Current Object',
-        type=bpy.types.Object)
+        type=bpy.types.Object,
+    )
     ob_id = IntProperty(default=0)
     mat = PointerProperty(
         name='Current Object Material',
-        type=bpy.types.Material)
+        type=bpy.types.Material,
+    )
     layer = IntProperty(
+        name='Material Layers',
         description='Materials with the same number will be merged together.'
                     '\nUse this to create multiple materials linked to the same atlas file',
         min=1,
         max=99,
         step=1,
-        default=1)
+        default=1,
+    )
     used = BoolProperty(default=True)
     type = IntProperty(default=0)
 
@@ -75,25 +79,28 @@ def register() -> None:
             ('STRICTCUST', 'Strict Custom', 'Combined image has exact custom width and height'),
         ],
         description='Select atlas size',
-        default='QUAD')
+        default='QUAD',
+    )
     bpy.types.Scene.smc_size_width = IntProperty(
         name='Max width (px)',
         description='Select max width for combined image',
         min=8,
         max=8192,
         step=1,
-        default=4096)
+        default=4096,
+    )
     bpy.types.Scene.smc_size_height = IntProperty(
         name='Max height (px)',
         description='Select max height for combined image',
         min=8,
         max=8192,
         step=1,
-        default=4096)
+        default=4096,
+    )
     bpy.types.Scene.smc_crop = BoolProperty(
         name='Crop outside images by UV',
         description='Crop images by UV if materials UV outside of bounds',
-        default=True
+        default=True,
     )
     bpy.types.Scene.smc_diffuse_size = IntProperty(
         name='Size of materials without image',
@@ -101,7 +108,8 @@ def register() -> None:
         min=8,
         max=256,
         step=1,
-        default=32)
+        default=32,
+    )
     bpy.types.Scene.smc_gaps = IntProperty(
         name='Size of gaps between images',
         description='Select size of gaps between images',
@@ -109,37 +117,44 @@ def register() -> None:
         max=32,
         step=200,
         default=0,
-        options={'HIDDEN'})
+        options={'HIDDEN'},
+    )
     bpy.types.Scene.smc_save_path = StringProperty(
         description='Select the directory in which the generated texture atlas will be saved',
-        default='')
+        default='',
+    )
 
     bpy.types.Material.root_mat = PointerProperty(
         name='Material Root',
-        type=bpy.types.Material)
+        type=bpy.types.Material,
+    )
     bpy.types.Material.smc_diffuse = BoolProperty(
         name='Multiply image with diffuse color',
         description='Multiply the materials image with its diffuse color.'
                     '\nINFO: If this color is white the final image will be the same',
-        default=True)
+        default=True,
+    )
     bpy.types.Material.smc_size = BoolProperty(
         name='Custom image size',
         description='Select the max size for this materials image in the texture atlas',
-        default=False)
+        default=False,
+    )
     bpy.types.Material.smc_size_width = IntProperty(
         name='Max width (px)',
         description='Select max width for material image',
         min=8,
         max=8192,
         step=1,
-        default=2048)
+        default=2048,
+    )
     bpy.types.Material.smc_size_height = IntProperty(
         name='Max height (px)',
         description='Select max height for material image',
         min=8,
         max=8192,
         step=1,
-        default=2048)
+        default=2048,
+    )
 
 
 def unregister() -> None:

--- a/operators/get-pip.py
+++ b/operators/get-pip.py
@@ -131,7 +131,7 @@ def bootstrap(tmpdir=None):
 
     # We want to support people passing things like 'pip<8' to get-pip.py which
     # will let them install a specific version. However, because of the dreaded
-    # DoubleRequirement error if any of the args look like they might be a
+    # DoubleRequirement error, if any of the args look like they might be a
     # specific for one of our packages, then we'll turn off the implicit
     # installation of them.
     for arg in args:

--- a/type_annotations.py
+++ b/type_annotations.py
@@ -13,7 +13,7 @@ BlClasses = Union[
     bpy.types.Panel, bpy.types.Operator, bpy.types.PropertyGroup, bpy.types.AddonPreferences, bpy.types.UIList
 ]
 
-SMCIcons = Union[bpy.utils.previews.ImagePreviewCollection, None]
+SMCIcons = Union[bpy.utils.previews.ImagePreviewCollection, Dict[str, bpy.types.ImagePreview], None]
 
 Scene = bpy.types.ViewLayer if globs.is_blender_2_80_or_newer else bpy.types.Scene
 
@@ -31,5 +31,9 @@ CombMats = Dict[int, bpy.types.Material]
 
 MatDictItem = List[bpy.types.Material]
 MatDict = DefaultDict[Tuple, MatDictItem]
+
+CombineListDataMat = Dict[str, Union[int, bool]]
+CombineListDataItem = Dict[str, Union[Dict[bpy.types.Material, CombineListDataMat], bool]]
+CombineListData = Dict[bpy.types.Object, CombineListDataItem]
 
 Diffuse = Union[bpy.types.bpy_prop_collection, Tuple[float, float, float], Tuple[int, int, int]]

--- a/ui/property_menu.py
+++ b/ui/property_menu.py
@@ -70,11 +70,13 @@ class PropertyMenu(bpy.types.Operator):
                             image: Optional[bpy.types.Image] = None) -> None:
         if globs.is_blender_2_79_or_older:
             col.prop(item.mat, 'smc_diffuse')
-            if item.mat.smc_diffuse:
-                split = col.row().split(factor=0.1) if globs.is_blender_2_80_or_newer else col.row().split(
-                    percentage=0.1)
-                split.separator()
-                split.prop(item.mat, 'diffuse_color', text='')
+            if not item.mat.smc_diffuse:
+                return
+
+            split = col.row().split(factor=0.1) if globs.is_blender_2_80_or_newer else col.row().split(
+                percentage=0.1)
+            split.separator()
+            split.prop(item.mat, 'diffuse_color', text='')
             return
 
         shader = get_shader_type(item.mat)
@@ -82,12 +84,17 @@ class PropertyMenu(bpy.types.Operator):
         if shader in ['principled', 'xnalara'] and image:
             return
 
-        col.prop(item.mat, 'smc_diffuse')
-        if not item.mat.smc_diffuse:
-            return
+        if image:
+            col.prop(item.mat, 'smc_diffuse')
+            if not item.mat.smc_diffuse:
+                return
 
-        split = col.row().split(factor=0.1) if globs.is_blender_2_80_or_newer else col.row().split(percentage=0.1)
+        split = (
+            col.row().split(factor=0.1) if globs.is_blender_2_80_or_newer and image else
+            col.row().split(percentage=0.1) if image else col
+        )
         split.separator()
+
         if shader in ['mmd', 'mmdCol']:
             split.prop(item.mat.node_tree.nodes['mmd_shader'].inputs['Diffuse Color'], 'default_value', text='')
         if shader in ['mtoon', 'mtoonCol']:

--- a/utils/images.py
+++ b/utils/images.py
@@ -1,3 +1,4 @@
+import os
 from typing import Union
 
 import bpy
@@ -8,6 +9,11 @@ def get_image(tex: bpy.types.Texture) -> bpy.types.Image:
 
 
 def get_packed_file(image: Union[bpy.types.Image, None]) -> Union[bpy.types.PackedFile, None]:
-    if image and not image.packed_file:
+    if image and not image.packed_file and _get_image_path(image):
         image.pack()
     return image.packed_file if image and image.packed_file else None
+
+
+def _get_image_path(img: Union[bpy.types.Image, None]) -> Union[str, None]:
+    path = os.path.abspath(bpy.path.abspath(img.filepath)) if img else ''
+    return path if os.path.isfile(path) and not path.lower().endswith(('.spa', '.sph')) else None

--- a/utils/materials.py
+++ b/utils/materials.py
@@ -1,6 +1,6 @@
 from collections import OrderedDict
 from collections import defaultdict
-from typing import Set
+from typing import List
 from typing import Union
 from typing import ValuesView
 from typing import cast
@@ -40,8 +40,8 @@ shader_image_nodes = {
 }
 
 
-def get_materials(ob: bpy.types.Object) -> Set[bpy.types.Material]:
-    return {mat_slot.material for mat_slot in ob.material_slots}
+def get_materials(ob: bpy.types.Object) -> List[bpy.types.Material]:
+    return [mat_slot.material for mat_slot in ob.material_slots if mat_slot.material]
 
 
 def get_shader_type(mat: bpy.types.Material) -> Union[str, None]:
@@ -70,7 +70,7 @@ def get_shader_type(mat: bpy.types.Material) -> Union[str, None]:
     )
 
 
-def sort_materials(mat_list: Set[bpy.types.Material]) -> ValuesView[MatDictItem]:
+def sort_materials(mat_list: List[bpy.types.Material]) -> ValuesView[MatDictItem]:
     for mat in bpy.data.materials:
         mat.root_mat = None
 
@@ -80,13 +80,13 @@ def sort_materials(mat_list: Set[bpy.types.Material]) -> ValuesView[MatDictItem]
 
         packed_file = None
 
-        if globs.is_blender_2_80_or_newer and node_tree:
+        if globs.is_blender_2_79_or_older:
+            packed_file = get_packed_file(get_image(get_texture(mat)))
+        elif node_tree:
             shader = get_shader_type(mat)
             node_name = shader_image_nodes.get(shader)
             if node_name:
                 packed_file = get_packed_file(node_tree.nodes[node_name].image)
-        else:
-            packed_file = get_packed_file(get_image(get_texture(mat)))
 
         if packed_file:
             mat_dict[(packed_file, get_diffuse(mat) if mat.smc_diffuse else None)].append(mat)


### PR DESCRIPTION
- Fixed material reselection on an object without selected materials
- Fixed missing materials in the combine list if they are the same
- Slightly redesigned the diffuse color in the property menu
- Fixed error when packing files that are missing on the drive
- Fixed texture packing error for Blender versions ranging from 2.8 to 3.0
- Code refactored