### PR TITLE
Add error msg with unknown shader type

### DIFF
--- a/operators/combiner/combiner.py
+++ b/operators/combiner/combiner.py
@@ -49,13 +49,15 @@ class Combiner(bpy.types.Operator):
         if self.cats:
             scn.smc_size = 'PO2'
             scn.smc_gaps = 0
-
-        set_ob_mode(context.view_layer if globs.is_blender_2_80_or_newer else scn, scn.smc_ob_data)
-        self.data = get_data(scn.smc_ob_data)
-        self.mats_uv = get_mats_uv(scn, self.data)
-        clear_empty_mats(scn, self.data, self.mats_uv)
-        get_duplicates(self.mats_uv)
-        self.structure = get_structure(scn, self.data, self.mats_uv)
+        try:
+            set_ob_mode(context.view_layer if globs.is_blender_2_80_or_newer else scn, scn.smc_ob_data)
+            self.data = get_data(scn.smc_ob_data)
+            self.mats_uv = get_mats_uv(scn, self.data)
+            clear_empty_mats(scn, self.data, self.mats_uv)
+            get_duplicates(self.mats_uv)
+            self.structure = get_structure(scn, self.data, self.mats_uv)
+        except ValueError as err:
+            return self._return_with_message('ERROR', str(err))
 
         if globs.is_blender_2_79_or_older:
             context.space_data.viewport_shade = 'MATERIAL'

--- a/utils/materials.py
+++ b/utils/materials.py
@@ -84,6 +84,8 @@ def sort_materials(mat_list: List[bpy.types.Material]) -> ValuesView[MatDictItem
             packed_file = get_packed_file(get_image(get_texture(mat)))
         elif node_tree:
             shader = get_shader_type(mat)
+            if shader == None:
+                raise ValueError(f"Shader type of {mat.name_full} cannot be recognized, see GitHub known issues")
             node_name = shader_image_nodes.get(shader)
             if node_name:
                 packed_file = get_packed_file(node_tree.nodes[node_name].image)


### PR DESCRIPTION
It confused me a lot that materials were replaced by the first selected one, until I found that textures were packed into .blend file , and that I should follow instructions on known issues column. Maybe we can add an error msg when shader type cannot be recognized, instead of packing these material as duplicated ones, to help users like me know what they should do.